### PR TITLE
remove unused where clause

### DIFF
--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -202,7 +202,7 @@ Calculates the regressive product of the MultiVectors a and b.
 (∨)(a::MultiVector{CA}, b::MultiVector{CA}) where {CA} = dual(dual(a) ∧ dual(b))
 (∨)(a::MultiVector{CA}, b::Real) where {CA} = a ∨ MultiVector(CA,b)
 (∨)(a::Real, b::MultiVector{CA}) where {CA} = MultiVector(CA,a) ∨ b
-(∨)(a::Real, b::Real) where {CA} = zero(promote_type(typeof(a),typeof(b)))
+(∨)(a::Real, b::Real) = zero(promote_type(typeof(a),typeof(b)))
 
 
 function generatesymprod(


### PR DESCRIPTION
Awesome package! This fixes a minor warning I got:
```julia
[ Info: Precompiling CliffordAlgebras [ca841f6f-225c-4bbd-a467-7a3512dfa6f6]
WARNING: method definition for ∨ at /home/jan/.julia/dev/CliffordAlgebras/src/arithmetic.jl:205 declares type variable CA but does not use it.
```