### PR TITLE
improve type inference and speedup norm

### DIFF
--- a/.github/workflows/Runtests.yml
+++ b/.github/workflows/Runtests.yml
@@ -2,7 +2,7 @@ name: Runtests
 on: [push, pull_request]
 jobs:
   test:
-    name: "Runtests ${{julia-version}}"
+    name: "Runtests ${{matrix.julia-version}}"
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/Runtests.yml
+++ b/.github/workflows/Runtests.yml
@@ -2,10 +2,11 @@ name: Runtests
 on: [push, pull_request]
 jobs:
   test:
+    name: "Runtests ${{julia-version}}"
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        julia-version: ['1.6']
+        julia-version: ['1.6', '1']
         julia-arch: [x64]
         os: [ubuntu-latest] # [ubuntu-latest, windows-latest, macOS-latest]
     steps:

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -666,20 +666,24 @@ end
 
 
 function exp_trig(mv::MultiVector)
-    if iszero(mv)
-        return one(mv)
+    T = float(eltype(mv))
+    x2 = sum(coefficients(mv) .^ 2, init=zero(T))
+    if iszero(x2)
+        one(T) + zero(T)*mv
     else
-        x = sqrt(sum(coefficients(mv) .^ 2))
-        return cos(x) + sin(x) * mv * inv(x)
+        x = sqrt(x2)
+        s,c = sincos(x)
+        c + s * mv * inv(x)
     end
 end
 
-
 function exp_hyp(mv::MultiVector)
-    if iszero(mv)
-        return one(mv)
+    T = float(eltype(mv))
+    x2 = sum(coefficients(mv) .^ 2, init=zero(T))
+    if iszero(x2)
+        return one(T) + zero(T) * mv
     else
-        x = sqrt(sum(coefficients(mv) .^ 2))
+        x = sqrt(x2)
         return cosh(x) + sinh(x) * mv * inv(x)
     end
 end

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -331,7 +331,7 @@ Calculates the anti-commutator ab+ba of two MultiVectors a and b.
         ) for n in BI
     )
     coeffsexpr = Expr(:call, :(NTuple{$K,$T}), Expr(:call, :tuple, coeffs...))
-    :(@inbounds MultiVector(Algebra(a), $BI, $coeffsexpr))
+    :(@inbounds MultiVector{$CA,$T,$BI,$K}($coeffsexpr))
 end
 
 """

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -376,10 +376,10 @@ Projects the MultiVector onto k-vectors. Similar to grade(mv,k), but uses
     T = eltype(mv)
     coeffs = (:(coefficients(mv)[$i]) for i in s)
     if length(coeffs) == 0
-        return :(MultiVector(Algebra(a), zero($T)))
+        return :(MultiVector($CA, zero($T)))
     end
     coeffsexpr = Expr(:call, :(NTuple{$K,$T}), Expr(:call, :tuple, coeffs...))
-    :(@inbounds MultiVector(Algebra(mv), $BI, $coeffsexpr))
+    :(@inbounds MultiVector{$CA,$T,$BI,$K}($coeffsexpr))
 end
 
 (Λᵏ)(mv::MultiVector, k::Integer) = Λᵏ(mv, Val(k))

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -664,28 +664,22 @@ Calling prune or grade before exp may help to find the best algorithm for the ex
     :(@inbounds $prodexpr)
 end
 
+function inv0(x)
+    y = inv(x)
+    ifelse(iszero(x), zero(y), y)
+end
 
 function exp_trig(mv::MultiVector)
     T = float(eltype(mv))
-    x2 = sum(coefficients(mv) .^ 2, init=zero(T))
-    if iszero(x2)
-        one(T) + zero(T)*mv
-    else
-        x = sqrt(x2)
-        s,c = sincos(x)
-        c + s * mv * inv(x)
-    end
+    x = sqrt(sum(coefficients(mv) .^ 2, init=zero(T)))
+    s,c = sincos(x)
+    return c + s * mv * inv0(x)
 end
 
 function exp_hyp(mv::MultiVector)
     T = float(eltype(mv))
-    x2 = sum(coefficients(mv) .^ 2, init=zero(T))
-    if iszero(x2)
-        return one(T) + zero(T) * mv
-    else
-        x = sqrt(x2)
-        return cosh(x) + sinh(x) * mv * inv(x)
-    end
+    x = sqrt(sum(coefficients(mv) .^ 2, init=zero(T)))
+    return cosh(x) + sinh(x) * mv * inv0(x)
 end
 
 

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -363,8 +363,7 @@ adjoint(mv::MultiVector) = polarize(mv)
 Projects the MultiVector onto k-vectors. Similar to grade(mv,k), but uses
 @generated code and compile time optimizations.
 """
-@generated function (Λᵏ)(mv::MultiVector, ::Val{k}) where {k}
-    CA = algebra(mv)
+@generated function (Λᵏ)(mv::MultiVector{CA}, ::Val{k}) where {CA,k}
     indexbounds =
         1 .+ (0, cumsum(ntuple(i -> binomial(order(CA), i - 1), 1 + order(CA)))...)
     @assert 0 < k + 1 < length(indexbounds) "k out of bounds."

--- a/src/multivector.jl
+++ b/src/multivector.jl
@@ -222,12 +222,12 @@ end
 
 Returns a new MultiVector with a non-sparse coefficient coding. This can be useful to manage type stability.
 """
-@generated function extend(mv::MultiVector{CA}) where CA
+@generated function extend(mv::MultiVector{CA,T}) where {CA,T}
     bi = baseindices(mv)
     d = dimension(CA)
     T = eltype(mv)
-    bexpr = Expr(:call,:tuple)
-    cexpr = Expr(:call,:tuple)
+    bexpr = Expr(:tuple)
+    cexpr = Expr(:tuple)
     for k = 1:d
         push!(bexpr.args, k)
         n = findfirst(isequal(k), bi)
@@ -237,7 +237,8 @@ Returns a new MultiVector with a non-sparse coefficient coding. This can be usef
             push!(cexpr.args, :(coefficients(mv)[$n]))
         end
     end
-    :(@inbounds MultiVector(CA, $bexpr, $cexpr))
+    K = length(bexpr.args)
+    :(@inbounds MultiVector{CA, $T, $bexpr, $K}($cexpr))
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,7 @@ using CliffordAlgebras
 using Test
 import LinearAlgebra.SingularException
 
-# @testset "CliffordAlgebras.jl" begin
+@testset "CliffordAlgebras.jl" begin
     @testset "inference" begin
         alg = CliffordAlgebra(1,1,1)
         @inferred 3*alg.e1
@@ -19,6 +19,24 @@ import LinearAlgebra.SingularException
         @inferred scalar(3*alg.e1)
         @inferred reverse(alg.e1 + 3*alg.e1e2)
         @inferred norm(alg.e1 + 3*alg.e1e2)
+
+        @testset "inference pga3d" begin
+            pga = CliffordAlgebra(3,0,1)
+            pt  = @inferred dual(pga.e4 + 3.2pga.e1 + 1.3pga.e2-4.3pga.e3)
+            pt1 = @inferred dual(pga.e4 + pga.e1)
+            pt2 = @inferred dual(pga.e4 + pga.e2 - pga.e3)
+            l = @inferred ∨(pt1, pt2)
+            l = @inferred l / norm(l)
+            motor1 = @inferred exp(-pi/6*l)
+            motor2 = @inferred exp(-1/2*pga.e3e4)
+            motor = @inferred motor1 * motor2
+
+            @inferred ≀(motor, pt)
+            @inferred ≀(motor1, pt)
+            @inferred ≀(motor2, pt)
+            @inferred ≀(motor, l)
+            @inferred ≀(motor, motor1)
+        end
     end
 
     @testset "isapprox" begin
@@ -497,6 +515,7 @@ import LinearAlgebra.SingularException
             end
 
             for mv in (e1, e2, e3, e12, e23, e31, e123)
+                @inferred exp(mv)
                 if scalar(mv*mv) < 0
                     @test exp(mv) == cos(1) + sin(1) * mv
                 elseif scalar(mv*mv) > 0
@@ -505,6 +524,7 @@ import LinearAlgebra.SingularException
                     @test exp(mv) == 1 + mv
                 end
                 @test convert(Float32,exp(mv) * exp(-mv)) ≈ 1
+                @test exp(0*mv) == 1
             end
 
             @test exp(1 + e1 + e12 + e123) == exp(1 + e123) * exp(e1 + e12)
@@ -535,4 +555,4 @@ import LinearAlgebra.SingularException
         end
 
     end
-# end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,7 @@ import LinearAlgebra.SingularException
         l = @inferred ∨(pt1, pt2)
         @inferred norm(l)
         l = @inferred l / norm(l)
+        @inferred CliffordAlgebras.exp_trig(-pi/6*l)
         motor1 = @inferred exp(-pi/6*l)
         motor2 = @inferred exp(-1/2*pga.e3e4)
         motor = @inferred motor1 * motor2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,6 @@
 using CliffordAlgebras
 using Test
 import LinearAlgebra.SingularException
-
-@testset "CliffordAlgebras.jl" begin
     @testset "inference pga3d" begin
         pga = CliffordAlgebra(3,0,1)
         pt  = @inferred dual(pga.e4 + 3.2pga.e1 + 1.3pga.e2-4.3pga.e3)
@@ -16,12 +14,20 @@ import LinearAlgebra.SingularException
         motor2 = @inferred exp(-1/2*pga.e3e4)
         motor = @inferred motor1 * motor2
 
+        @inferred Λᵏ(motor, Val(0))
+        @inferred Λᵏ(motor, Val(1))
+        @inferred Λᵏ(motor, Val(2))
+        @inferred Λᵏ(motor, Val(3))
+        @inferred Λᵏ(motor, Val(4))
+
         @inferred ≀(motor, pt)
         @inferred ≀(motor1, pt)
         @inferred ≀(motor2, pt)
         @inferred ≀(motor, l)
         @inferred ≀(motor, motor1)
     end
+
+@testset "CliffordAlgebras.jl" begin
 
     @testset "isapprox" begin
         Cl = CliffordAlgebra

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,40 +3,23 @@ using Test
 import LinearAlgebra.SingularException
 
 @testset "CliffordAlgebras.jl" begin
-    @testset "inference" begin
-        alg = CliffordAlgebra(1,1,1)
-        @inferred 3*alg.e1
-        @inferred 3.0*alg.e1
-        @inferred alg.e1*3f0
-        @inferred (3alg.e1) * (alg.e2)
-        @inferred alg.e1 ∧ 2.3
-    
-        @inferred dual(alg.e1)
-        @inferred dual(alg.e1 + alg.e1e2)
-        @inferred alg.e1 ∨ (alg.e2e3 + 1)
-    
-        @inferred scalar(alg.e1)
-        @inferred scalar(3*alg.e1)
-        @inferred reverse(alg.e1 + 3*alg.e1e2)
-        @inferred norm(alg.e1 + 3*alg.e1e2)
+    @testset "inference pga3d" begin
+        pga = CliffordAlgebra(3,0,1)
+        pt  = @inferred dual(pga.e4 + 3.2pga.e1 + 1.3pga.e2-4.3pga.e3)
+        pt1 = @inferred dual(pga.e4 + pga.e1)
+        pt2 = @inferred dual(pga.e4 + pga.e2 - pga.e3)
+        l = @inferred ∨(pt1, pt2)
+        @inferred norm(l)
+        l = @inferred l / norm(l)
+        motor1 = @inferred exp(-pi/6*l)
+        motor2 = @inferred exp(-1/2*pga.e3e4)
+        motor = @inferred motor1 * motor2
 
-        @testset "inference pga3d" begin
-            pga = CliffordAlgebra(3,0,1)
-            pt  = @inferred dual(pga.e4 + 3.2pga.e1 + 1.3pga.e2-4.3pga.e3)
-            pt1 = @inferred dual(pga.e4 + pga.e1)
-            pt2 = @inferred dual(pga.e4 + pga.e2 - pga.e3)
-            l = @inferred ∨(pt1, pt2)
-            l = @inferred l / norm(l)
-            motor1 = @inferred exp(-pi/6*l)
-            motor2 = @inferred exp(-1/2*pga.e3e4)
-            motor = @inferred motor1 * motor2
-
-            @inferred ≀(motor, pt)
-            @inferred ≀(motor1, pt)
-            @inferred ≀(motor2, pt)
-            @inferred ≀(motor, l)
-            @inferred ≀(motor, motor1)
-        end
+        @inferred ≀(motor, pt)
+        @inferred ≀(motor1, pt)
+        @inferred ≀(motor2, pt)
+        @inferred ≀(motor, l)
+        @inferred ≀(motor, motor1)
     end
 
     @testset "isapprox" begin
@@ -210,6 +193,24 @@ import LinearAlgebra.SingularException
         s1 = scalar(e1*e1)
         s2 = scalar(e2*e2)
         s3 = scalar(e3*e3)
+
+        @testset "inference" begin
+            @inferred 3*e1
+            @inferred 3.0*e1
+            @inferred e1*3f0
+            @inferred (3e1) * (e2)
+            @inferred e1 ∧ 2.3
+            @inferred -e1
+        
+            @inferred dual(e1)
+            @inferred dual(e1 + e12)
+            @inferred e1 ∨ (e23 + 1)
+        
+            @inferred scalar(e1)
+            @inferred scalar(3*e1)
+            @inferred reverse(e1 + 3*e12)
+            @inferred norm(e1 + 3*e12)
+        end
 
         @testset "addition/subtraction" begin
             @test e1 + e2 == e2 + e1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,25 @@ using CliffordAlgebras
 using Test
 import LinearAlgebra.SingularException
 
-@testset "CliffordAlgebras.jl" begin
+# @testset "CliffordAlgebras.jl" begin
+    @testset "inference" begin
+        alg = CliffordAlgebra(1,1,1)
+        @inferred 3*alg.e1
+        @inferred 3.0*alg.e1
+        @inferred alg.e1*3f0
+        @inferred (3alg.e1) * (alg.e2)
+        @inferred alg.e1 ∧ 2.3
+    
+        @inferred dual(alg.e1)
+        @inferred dual(alg.e1 + alg.e1e2)
+        @inferred alg.e1 ∨ (alg.e2e3 + 1)
+    
+        @inferred scalar(alg.e1)
+        @inferred scalar(3*alg.e1)
+        @inferred reverse(alg.e1 + 3*alg.e1e2)
+        @inferred norm(alg.e1 + 3*alg.e1e2)
+    end
+
     @testset "isapprox" begin
         Cl = CliffordAlgebra
         @test Cl(1,1,1).e1 ≈ Cl(1,1,1).e1
@@ -319,6 +337,11 @@ import LinearAlgebra.SingularException
 
             @test 2 ∨ e1 == MultiVector(cl,2) ∨ e1
             @test 2 ∨ 3 == MultiVector(cl,2) ∨ MultiVector(cl,3)
+
+            @test 1 ∨ 2 == 0
+            @test e1 ∨ 2 == 0
+            @test e12 ∨ 2 == 0
+            @test e123 ∨ 2 == 2
         end
 
         @testset "commutator product" begin
@@ -394,6 +417,16 @@ import LinearAlgebra.SingularException
             @test mva ≀ mvb == mva * mvb * reverse(mva)
         end
 
+        @testset "norm" begin
+            r = -100:100
+            mv  = rand(r) + rand(r) * e1 + 
+                  rand(r) * e2 + rand(r) * e3 + 
+                  rand(r) * e12 + rand(r) * e23 +
+                  rand(r) * e31 + rand(r) * e123
+            
+            @test norm(mv) ≈ sqrt(Complex(scalar(mv*reverse(mv))))
+        end
+
         @testset "misc functions" begin
             mv = 1 + e1 - e2 + e3 + e12 - e23 + e31 - e123
             @test polarize(mv)*pseudoscalar(algebra(mv)) == character(algebra(mv))
@@ -415,6 +448,8 @@ import LinearAlgebra.SingularException
 
             @test norm(2*e1) == 2*s1
             @test norm(-2*e1) == 2*s1
+
+            @test norm(e1+2*e31) ≈ sqrt(norm(e1)^2 + 2*norm(e31))
 
             if !iszero(s1)
                 @test inv(e1) * e1 == e1 * inv(e1) == 1 
@@ -500,4 +535,4 @@ import LinearAlgebra.SingularException
         end
 
     end
-end
+# end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,6 +19,7 @@ import LinearAlgebra.SingularException
         @inferred Λᵏ(motor, Val(2))
         @inferred Λᵏ(motor, Val(3))
         @inferred Λᵏ(motor, Val(4))
+        @inferred extend(motor)
 
         @inferred ≀(motor, pt)
         @inferred ≀(motor1, pt)


### PR DESCRIPTION
Fixes various inference and performance issues. The most extreme one:
```julia
using CliffordAlgebras
using BenchmarkTools

pga = CliffordAlgebra(3,0,1)

mv = dual(pga.e4 + 3.2pga.e1 + 1.3pga.e2-4.3pga.e3)
 
@btime norm($mv)

# before:  74.091 ns (4 allocations: 96 bytes)

# after:   1.560 ns (0 allocations: 0 bytes)
```

In an actual use case that involves 3d PGA this gives me a nice speedup:
```
# Before:
5.78 seconds 4.9GiB allocs
# After:
0.072 seconds 1.679 MiB allocs
```

