### PR TITLE
make tests run much faster

### DIFF
--- a/src/algebra.jl
+++ b/src/algebra.jl
@@ -70,7 +70,7 @@ struct CliffordAlgebra{Np,Nn,Nz,S,BT}
         Nzero = Int(Nzero)
         @assert Npos >= 0 && Nneg >= 0 && Nzero >=0 "Algebra signature must be non-negative."
         @assert Npos + Nneg + Nzero == N "Base symbol count must match signature."
-        BT = adaptbasefordual(enumeratebase(Int(N)))
+        BT = adaptbasefordual(enumeratebase(Vector, Int(N)))
         new{Npos,Nneg,Nzero,BaseSymbols,BT}()
     end
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -25,7 +25,10 @@ end
 
 Generates the basis vector product combinations for the Clifford algebra of an N dimensional vector space.
 """
-function enumeratebase(N::Integer)
+function enumeratebase(N::Integer)::Tuple
+    Tuple(enumeratebase(Vector, N))
+end
+function enumeratebase(::Type{Vector}, N::Integer)::Vector
     result = Tuple[]
     push!(result, ())
     for n = 1:N
@@ -36,7 +39,8 @@ function enumeratebase(N::Integer)
             !isnothing(s) || break
         end
     end
-    Tuple(result)
+    @assert length(result) == 2^N
+    return result
 end
 
 
@@ -45,7 +49,7 @@ end
 
 Shuffles the base vector products so that the Poincaré dual of every basis vector is another basis vector.
 """
-function adaptbasefordual(base)
+function adaptbasefordual(base)::Tuple
     N = length(base)
     Nh = N ÷ 2
     Tuple(


### PR DESCRIPTION
# Before

```julia
julia> @time include("test/runtests.jl");
Test Summary:       | Pass  Total     Time
CliffordAlgebras.jl | 2511   2511  2m53.5s
197.829084 seconds (8.98 M allocations: 1.078 TiB, 37.20% gc time, 12.09% compilation time)
```

# After

```julia
julia> @time include("test/runtests.jl");
Test Summary:       | Pass  Total  Time
CliffordAlgebras.jl | 2511   2511  0.2s
 26.239201 seconds (7.46 M allocations: 637.263 MiB, 1.01% gc time, 97.76% compilation time)
```