### PR TITLE
Expanded coefficients and Added broadcasting for * and /

### DIFF
--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -640,9 +640,9 @@ function broadcasted(::typeof(/), a::MultiVector{CA,Ta,BI}, b::MultiVector{CA,Tb
 end
 
 function broadcasted(::typeof(/), a::MultiVector{CA,Ta,BIa}, b::MultiVector{CA,Tb,BIb})::MultiVector where {CA,Ta,Tb,BIa,BIb}
-    BI = tuple(union(BIa, BIb)...)
-    v1, v2 = coefficients(a, BI), coefficients(b, BI)
-    return MultiVector(CA, BI, v1 ./ v2)
+    @assert BIa ⊆ BIb
+    v1, v2 = coefficients(a, BIb), coefficients(b, BIb)
+    return MultiVector(CA, BIb, v1 ./ v2)
 end
 
 """

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -1,6 +1,7 @@
 # MultiVector arithmetic for CliffordAlgebras.jl
 
 import Base.+, Base.-, Base.*, Base./, Base.\
+import Base.broadcasted
 import Base.inv, Base.adjoint, Base.exp
 import LinearAlgebra.norm, LinearAlgebra.norm_sqr
 import LinearAlgebra.SingularException
@@ -148,6 +149,21 @@ end
 
 function mul_with_scalar(s::Real,mv::MultiVector)
     map_coefficients(x->s*x,mv)
+end
+
+"""
+    mv1 .* mv2
+
+Calculates the element wise product between the Mulivectors a and b.
+"""
+function broadcasted(::typeof(*), a::MultiVector{CA,Ta,BI}, b::MultiVector{CA,Tb,BI})::MultiVector where {CA,Ta,Tb,BI}
+    return MultiVector(CA, BI, coefficients(a) .* coefficients(b))
+end
+
+function broadcasted(::typeof(*), a::MultiVector{CA,Ta,BIa}, b::MultiVector{CA,Tb,BIb})::MultiVector where {CA,Ta,Tb,BIa,BIb}
+    BI = tuple(union(BIa, BIb)...)
+    v1, v2 = coefficients(a, BI), coefficients(b, BI)
+    return MultiVector(CA, BI, v1 .* v2)
 end
 
 """
@@ -417,6 +433,7 @@ function Base.isapprox(mv1::MultiVector, mv2::MultiVector;
         rtol=default_rtol(mv1, mv2),
 )
     algebra(mv1) === algebra(mv2) || return false
+    iszero(mv1) && iszero(mv2) && return true
     n1 = norm(coefficients(mv1))
     n2 = norm(coefficients(mv2))
     n12 = norm(coefficients(mv1 - mv2))
@@ -612,6 +629,21 @@ Calculates the MultiVector quotient a/b by evaluating inv(b)*a.
 (\)(a::MultiVector{CA}, b::MultiVector{CA}) where {CA} = inv(a) * b
 (\)(a::Real, b::MultiVector{CA}) where {CA} = inv(a) * b
 (\)(a::MultiVector{CA}, b::Real) where {CA} = inv(a) * b
+
+"""
+    a ./ b
+
+Calculates the element wise division between the MultiVectors a and b.
+"""
+function broadcasted(::typeof(/), a::MultiVector{CA,Ta,BI}, b::MultiVector{CA,Tb,BI})::MultiVector where {CA,Ta,Tb,BI}
+    return MultiVector(CA, BI, coefficients(a) ./ coefficients(b))
+end
+
+function broadcasted(::typeof(/), a::MultiVector{CA,Ta,BIa}, b::MultiVector{CA,Tb,BIb})::MultiVector where {CA,Ta,Tb,BIa,BIb}
+    BI = tuple(union(BIa, BIb)...)
+    v1, v2 = coefficients(a, BI), coefficients(b, BI)
+    return MultiVector(CA, BI, v1 ./ v2)
+end
 
 """
     exp(::MultiVector)

--- a/src/multivector.jl
+++ b/src/multivector.jl
@@ -106,6 +106,26 @@ coefficients(mv::MultiVector) = getfield(mv,:c)
 
 
 """
+    coefficient(::MultiVector, n::Union{NTuple, AbstractVector})
+
+Returns the multivector coefficients for the given basis tuple or vector.
+Returns 0 if index is out of bounds.
+"""
+function coefficients(
+    mv::MultiVector{CA,T}, 
+    idxs::I
+)::I where {CA, T, I<:Union{NTuple, AbstractVector}}
+    bases = baseindices(mv)
+    coeffs = getfield(mv, :c)
+
+    return map(idxs) do idx
+        n = findfirst(isequal(idx), bases)
+        isnothing(n) ? zero(T) : coeffs[n]
+    end
+end
+
+
+"""
     coefficient(::MultiVector, n::Integer)
 
 Returns the multivector coefficients for the n-th basis vector. Returns 0 if n is out of bounds.

--- a/src/multivector.jl
+++ b/src/multivector.jl
@@ -106,20 +106,39 @@ coefficients(mv::MultiVector) = getfield(mv,:c)
 
 
 """
-    coefficient(::MultiVector, n::Union{NTuple, AbstractVector})
+    coefficients(::MultiVector, n::Union{NTuple{Integer}, AbstractVector{Integer}})
 
-Returns the multivector coefficients for the given basis tuple or vector.
+Returns the multivector coefficients for the given tuple/vector of basis indices.
 Returns 0 if index is out of bounds.
 """
 function coefficients(
     mv::MultiVector{CA,T}, 
-    idxs::I
-)::I where {CA, T, I<:Union{NTuple, AbstractVector}}
+    idxs::U
+) where {CA, T, U<:Union{NTuple{N,I} where {N}, AbstractVector{I}} where {I<:Integer}}
     bases = baseindices(mv)
     coeffs = getfield(mv, :c)
 
     return map(idxs) do idx
         n = findfirst(isequal(idx), bases)
+        isnothing(n) ? zero(T) : coeffs[n]
+    end
+end
+
+"""
+    coefficients(::MultiVector, n::Union{NTuple{Symbol}, AbstractVector{Symbol}})
+
+Returns the multivector coefficients for the given tuple/vector of basis symbols.
+Returns 0 if the symbol is not a valid basis symbol.
+"""
+function coefficients(
+    mv::MultiVector{CA,T}, 
+    syms::U
+) where {CA, T, U<:Union{NTuple{N,Symbol} where {N}, AbstractVector{Symbol}}}
+    bases = baseindices(mv)
+    coeffs = getfield(mv, :c)
+
+    return map(syms) do sym
+        n = findfirst(i -> isequal(sym, basesymbol(CA,i)), bases)
         isnothing(n) ? zero(T) : coeffs[n]
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -50,6 +50,8 @@ import LinearAlgebra.SingularException
         @test !isapprox(alg.e1, 1, atol=1)
         @test isapprox(1, alg.e1, atol=2)
         @test !isapprox(1, alg.e1, atol=1)
+        @test isapprox(0alg.e1, 0alg.e1)
+        @test isapprox(0alg.e1, 0alg.e2)
     end
     @testset "Algebra" begin
         @test CliffordAlgebra(1,0,0) == CliffordAlgebra(1)
@@ -450,6 +452,69 @@ import LinearAlgebra.SingularException
                   rand(r) * e31 + rand(r) * e123
 
             @test mva ≀ mvb == mva * mvb * reverse(mva)
+        end
+
+        @testset "coefficients" begin
+            pga = typeof(CliffordAlgebra(:PGA3D))
+            mv = MultiVector(pga, (1:16...,), (101:116...,))
+            fib_ntuple = (1, 2, 3, 5, 8, 13)
+            fib_vec = [1, 2, 3, 5, 8, 13]
+            
+            @test coefficients(mv, fib_ntuple) == fib_ntuple .+ 100
+            @test coefficients(mv, fib_vec) == fib_vec .+ 100
+        end
+        
+        @testset "broadcasted" begin
+            pga = typeof(CliffordAlgebra(:PGA2D))
+            mvs = [
+                MultiVector(pga, (1:3...,), (2,2,2)),
+                MultiVector(pga, (1:6...,), (3,3,3,3,3,3)),
+                MultiVector(pga, (4:8...,), (5,5,5,5,5)),
+                MultiVector(pga, (1:8...,), (7,7,7,7,7,7,7,7)),
+            ]
+        
+            mv_muls = [
+                MultiVector(pga, (1, 2, 3), (4, 4, 4))
+                MultiVector(pga, (1, 2, 3), (6, 6, 6))
+                MultiVector(pga, (1, 2, 3, 4, 5, 6, 7, 8), (0, 0, 0, 0, 0, 0, 0, 0))
+                MultiVector(pga, (1, 2, 3), (14, 14, 14))
+                MultiVector(pga, (1, 2, 3), (6, 6, 6))
+                MultiVector(pga, (1, 2, 3, 4, 5, 6), (9, 9, 9, 9, 9, 9))
+                MultiVector(pga, (4, 5, 6), (15, 15, 15))
+                MultiVector(pga, (1, 2, 3, 4, 5, 6), (21, 21, 21, 21, 21, 21))
+                MultiVector(pga, (1, 2, 3, 4, 5, 6, 7, 8), (0, 0, 0, 0, 0, 0, 0, 0))
+                MultiVector(pga, (4, 5, 6), (15, 15, 15))
+                MultiVector(pga, (4, 5, 6, 7, 8), (25, 25, 25, 25, 25))
+                MultiVector(pga, (4, 5, 6, 7, 8), (35, 35, 35, 35, 35))
+                MultiVector(pga, (1, 2, 3), (14, 14, 14))
+                MultiVector(pga, (1, 2, 3, 4, 5, 6), (21, 21, 21, 21, 21, 21))
+                MultiVector(pga, (4, 5, 6, 7, 8), (35, 35, 35, 35, 35))
+                MultiVector(pga, (1, 2, 3, 4, 5, 6, 7, 8), (49, 49, 49, 49, 49, 49, 49, 49))
+            ]
+        
+            mv_divs = [
+                MultiVector(pga, (1, 2, 3), (1.0, 1.0, 1.0))
+                MultiVector(pga, (1, 2, 3), (0.6666666666666666, 0.6666666666666666, 0.6666666666666666))
+                MultiVector(pga, (1, 2, 3), (Inf, Inf, Inf))
+                MultiVector(pga, (1, 2, 3), (0.2857142857142857, 0.2857142857142857, 0.2857142857142857))
+                MultiVector(pga, (1, 2, 3, 4, 5, 6), (1.5, 1.5, 1.5, Inf, Inf, Inf))
+                MultiVector(pga, (1, 2, 3, 4, 5, 6), (1.0, 1.0, 1.0, 1.0, 1.0, 1.0))
+                MultiVector(pga, (1, 2, 3, 4, 5, 6), (Inf, Inf, Inf, 0.6, 0.6, 0.6))
+                MultiVector(pga, (1, 2, 3, 4, 5, 6), (0.42857142857142855, 0.42857142857142855, 0.42857142857142855, 0.42857142857142855, 0.42857142857142855, 0.42857142857142855))
+                MultiVector(pga, (4, 5, 6, 7, 8), (Inf, Inf, Inf, Inf, Inf))
+                MultiVector(pga, (4, 5, 6, 7, 8), (1.6666666666666667, 1.6666666666666667, 1.6666666666666667, Inf, Inf))
+                MultiVector(pga, (4, 5, 6, 7, 8), (1.0, 1.0, 1.0, 1.0, 1.0))
+                MultiVector(pga, (4, 5, 6, 7, 8), (0.7142857142857143, 0.7142857142857143, 0.7142857142857143, 0.7142857142857143, 0.7142857142857143))
+                MultiVector(pga, (1, 2, 3, 4, 5, 6, 7, 8), (3.5, 3.5, 3.5, Inf, Inf, Inf, Inf, Inf))
+                MultiVector(pga, (1, 2, 3, 4, 5, 6, 7, 8), (2.3333333333333335, 2.3333333333333335, 2.3333333333333335, 2.3333333333333335, 2.3333333333333335, 2.3333333333333335, Inf, Inf))
+                MultiVector(pga, (1, 2, 3, 4, 5, 6, 7, 8), (Inf, Inf, Inf, 1.4, 1.4, 1.4, 1.4, 1.4))
+                MultiVector(pga, (1, 2, 3, 4, 5, 6, 7, 8), (1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0))
+            ]
+        
+            for ((mv1, mv2), mv_mul, mv_div) in zip(Iterators.product(mvs, mvs),  mv_muls, mv_divs)
+                @test isapprox((mv1 .* mv2), mv_mul)
+                @test isapprox(vector(mv2 ./ mv1), vector(mv_div))
+            end
         end
 
         @testset "norm" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -456,15 +456,26 @@ import LinearAlgebra.SingularException
 
         @testset "coefficients" begin
             pga = typeof(CliffordAlgebra(:PGA3D))
-            mv = MultiVector(pga, (1:16...,), (101:116...,))
+            mv_int = MultiVector(pga, (1:16...,), (101:116...,))
+            mv_float = MultiVector(pga, (1:16...,), (101.5:116.5...,))
+            
             fib_ntuple = (1, 2, 3, 5, 8, 13)
             fib_vec = [1, 2, 3, 5, 8, 13]
+            sym_ntuple = (:𝟏, :e1, :e2, :e0, :e2e3, :e1e2e0)
+            sym_vec = [:𝟏, :e1, :e2, :e0, :e2e3, :e1e2e0]
             
-            @test coefficients(mv, fib_ntuple) == fib_ntuple .+ 100
-            @test coefficients(mv, fib_vec) == fib_vec .+ 100
+            @test coefficients(mv_int, fib_ntuple) == fib_ntuple .+ 100
+            @test coefficients(mv_int, fib_vec) == fib_vec .+ 100
+            @test coefficients(mv_float, fib_ntuple) == fib_ntuple .+ 100.5
+            @test coefficients(mv_float, fib_vec) == fib_vec .+ 100.5
+            
+            @test coefficients(mv_int, sym_ntuple) == fib_ntuple .+ 100
+            @test coefficients(mv_int, sym_vec) == fib_vec .+ 100
+            @test coefficients(mv_float, sym_ntuple) == fib_ntuple .+ 100.5
+            @test coefficients(mv_float, sym_vec) == fib_vec .+ 100.5
         end
         
-        @testset "broadcasted" begin
+        @testset "broadcasted .*" begin
             pga = typeof(CliffordAlgebra(:PGA2D))
             mvs = [
                 MultiVector(pga, (1:3...,), (2,2,2)),
@@ -472,49 +483,38 @@ import LinearAlgebra.SingularException
                 MultiVector(pga, (4:8...,), (5,5,5,5,5)),
                 MultiVector(pga, (1:8...,), (7,7,7,7,7,7,7,7)),
             ]
-        
-            mv_muls = [
-                MultiVector(pga, (1, 2, 3), (4, 4, 4))
-                MultiVector(pga, (1, 2, 3), (6, 6, 6))
-                MultiVector(pga, (1, 2, 3, 4, 5, 6, 7, 8), (0, 0, 0, 0, 0, 0, 0, 0))
-                MultiVector(pga, (1, 2, 3), (14, 14, 14))
-                MultiVector(pga, (1, 2, 3), (6, 6, 6))
-                MultiVector(pga, (1, 2, 3, 4, 5, 6), (9, 9, 9, 9, 9, 9))
-                MultiVector(pga, (4, 5, 6), (15, 15, 15))
-                MultiVector(pga, (1, 2, 3, 4, 5, 6), (21, 21, 21, 21, 21, 21))
-                MultiVector(pga, (1, 2, 3, 4, 5, 6, 7, 8), (0, 0, 0, 0, 0, 0, 0, 0))
-                MultiVector(pga, (4, 5, 6), (15, 15, 15))
-                MultiVector(pga, (4, 5, 6, 7, 8), (25, 25, 25, 25, 25))
-                MultiVector(pga, (4, 5, 6, 7, 8), (35, 35, 35, 35, 35))
-                MultiVector(pga, (1, 2, 3), (14, 14, 14))
-                MultiVector(pga, (1, 2, 3, 4, 5, 6), (21, 21, 21, 21, 21, 21))
-                MultiVector(pga, (4, 5, 6, 7, 8), (35, 35, 35, 35, 35))
-                MultiVector(pga, (1, 2, 3, 4, 5, 6, 7, 8), (49, 49, 49, 49, 49, 49, 49, 49))
-            ]
-        
-            mv_divs = [
-                MultiVector(pga, (1, 2, 3), (1.0, 1.0, 1.0))
-                MultiVector(pga, (1, 2, 3), (0.6666666666666666, 0.6666666666666666, 0.6666666666666666))
-                MultiVector(pga, (1, 2, 3), (Inf, Inf, Inf))
-                MultiVector(pga, (1, 2, 3), (0.2857142857142857, 0.2857142857142857, 0.2857142857142857))
-                MultiVector(pga, (1, 2, 3, 4, 5, 6), (1.5, 1.5, 1.5, Inf, Inf, Inf))
-                MultiVector(pga, (1, 2, 3, 4, 5, 6), (1.0, 1.0, 1.0, 1.0, 1.0, 1.0))
-                MultiVector(pga, (1, 2, 3, 4, 5, 6), (Inf, Inf, Inf, 0.6, 0.6, 0.6))
-                MultiVector(pga, (1, 2, 3, 4, 5, 6), (0.42857142857142855, 0.42857142857142855, 0.42857142857142855, 0.42857142857142855, 0.42857142857142855, 0.42857142857142855))
-                MultiVector(pga, (4, 5, 6, 7, 8), (Inf, Inf, Inf, Inf, Inf))
-                MultiVector(pga, (4, 5, 6, 7, 8), (1.6666666666666667, 1.6666666666666667, 1.6666666666666667, Inf, Inf))
-                MultiVector(pga, (4, 5, 6, 7, 8), (1.0, 1.0, 1.0, 1.0, 1.0))
-                MultiVector(pga, (4, 5, 6, 7, 8), (0.7142857142857143, 0.7142857142857143, 0.7142857142857143, 0.7142857142857143, 0.7142857142857143))
-                MultiVector(pga, (1, 2, 3, 4, 5, 6, 7, 8), (3.5, 3.5, 3.5, Inf, Inf, Inf, Inf, Inf))
-                MultiVector(pga, (1, 2, 3, 4, 5, 6, 7, 8), (2.3333333333333335, 2.3333333333333335, 2.3333333333333335, 2.3333333333333335, 2.3333333333333335, 2.3333333333333335, Inf, Inf))
-                MultiVector(pga, (1, 2, 3, 4, 5, 6, 7, 8), (Inf, Inf, Inf, 1.4, 1.4, 1.4, 1.4, 1.4))
-                MultiVector(pga, (1, 2, 3, 4, 5, 6, 7, 8), (1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0))
-            ]
-        
-            for ((mv1, mv2), mv_mul, mv_div) in zip(Iterators.product(mvs, mvs),  mv_muls, mv_divs)
-                @test isapprox((mv1 .* mv2), mv_mul)
-                @test isapprox(vector(mv2 ./ mv1), vector(mv_div))
+            
+            for mv1 in mvs, mv2 in mvs
+                @test isapprox(vector(mv1 .* mv2), vector(mv1) .* vector(mv2))
             end
+        end
+
+        @testset "broadcasted ./" begin
+            pga = typeof(CliffordAlgebra(:PGA2D))
+
+            function semi_safe_divide(x, y)
+                if x == 0 && y == 0
+                    return 0
+                else
+                    return x / y
+                end
+            end
+
+            mv_zero = MultiVector(pga, (1:3...,), (0, 0, 0))
+            mv_small = MultiVector(pga, (1:3...,), (2, 2, 2))
+            mv_full = MultiVector(pga, (1:8...,), (7, 7, 7, 7, 7, 7, 7, 7))
+
+            @test isapprox(vector(mv_small ./ mv_zero), [Inf, Inf, Inf, 0, 0, 0, 0, 0])
+            @test isapprox(vector(mv_small ./ mv_zero), semi_safe_divide.(vector(mv_small), vector(mv_zero)))
+            @test_throws AssertionError mv_full ./ mv_zero
+
+            @test isapprox(vector(mv_zero ./ mv_small), semi_safe_divide.(vector(mv_zero), vector(mv_small)))
+            @test isapprox(vector(mv_small ./ mv_small), semi_safe_divide.(vector(mv_small), vector(mv_small)))
+            @test_throws AssertionError mv_full ./ mv_small
+
+            @test isapprox(vector(mv_zero ./ mv_full), semi_safe_divide.(vector(mv_zero), vector(mv_full)))
+            @test isapprox(vector(mv_small ./ mv_full), semi_safe_divide.(vector(mv_small), vector(mv_full)))
+            @test isapprox(vector(mv_full ./ mv_full), semi_safe_divide.(vector(mv_full), vector(mv_full)))
         end
 
         @testset "norm" begin


### PR DESCRIPTION
Added broadcasting to allow for inertial maps in PGA physics.
```julia
Base.broadcasted(::typeof(*), a::MultiVector, b::MultiVector)::MultiVector
Base.broadcasted(::typeof(/), a::MultiVector, b::MultiVector)::MultiVector
```
Added the ability to grab a tuple or vector of coefficients from a MultiVector. This allows for grabbing the coefficients of a sub algebra.
```julia
coefficients(mv::MultiVector, idxs::Union{NTuple, AbstractVector})
```

Fixed a bug where isapprox(0*alg.e1, 0*alg.e1) returns false.